### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/cpp/tools/cmap_data_generator_xml.py
+++ b/cpp/tools/cmap_data_generator_xml.py
@@ -67,6 +67,6 @@ class CMapDataGeneratorXML(object):
       entry = cmap_entries[i]
       mapping_element = self.document.createElement('map')
       cmap_element.appendChild(mapping_element)
-      mapping_element.setAttribute('char', '0x%05x' % entry[0])
+      mapping_element.setAttribute('char', '0x{0:05x}'.format(entry[0]))
       mapping_element.setAttribute('glyph_name', entry[1])
       mapping_element.setAttribute('gid', str(self.font.getGlyphID(entry[1])))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:sfntly?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:sfntly?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
